### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/proteins/extrest/tables.py
+++ b/proteins/extrest/tables.py
@@ -27,7 +27,7 @@ def fetch_pmc_content(pmcid):
 
 
 def fetch_doi_content(doi):
-    return requests.get('http://dx.doi.org/' + doi)
+    return requests.get('https://doi.org/' + doi)
 
 
 def response2table2(response):

--- a/proteins/forms.py
+++ b/proteins/forms.py
@@ -55,7 +55,7 @@ class DOIField(forms.CharField):
 
     def to_python(self, value):
         if value and isinstance(value, str):
-            value = value.lstrip('https://dx.doi.org/')
+            value = value.lstrip('https://doi.org/')
         return super().to_python(value)
 
 

--- a/proteins/forms.py
+++ b/proteins/forms.py
@@ -56,7 +56,7 @@ class DOIField(forms.CharField):
 
     def to_python(self, value):
         if value and isinstance(value, str):
-            value = value.sub('^https?://(dx\.)?doi.org/')
+            value = value.sub('^https?://(dx\.)?doi.org/', '')
         return super().to_python(value)
 
 

--- a/proteins/forms.py
+++ b/proteins/forms.py
@@ -5,7 +5,7 @@ from django.forms.models import inlineformset_factory  # ,BaseInlineFormSet
 from django.apps import apps
 from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
-import re import sub
+from re import sub
 from proteins.models import (Protein, State, StateTransition, Spectrum,
                              ProteinCollection, BleachMeasurement)
 from proteins.validators import validate_spectrum, validate_doi, protein_sequence_validator

--- a/proteins/forms.py
+++ b/proteins/forms.py
@@ -5,7 +5,7 @@ from django.forms.models import inlineformset_factory  # ,BaseInlineFormSet
 from django.apps import apps
 from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
-from re import sub
+import re
 from proteins.models import (Protein, State, StateTransition, Spectrum,
                              ProteinCollection, BleachMeasurement)
 from proteins.validators import validate_spectrum, validate_doi, protein_sequence_validator
@@ -56,7 +56,7 @@ class DOIField(forms.CharField):
 
     def to_python(self, value):
         if value and isinstance(value, str):
-            value = value.sub('^https?://(dx\.)?doi.org/', '')
+            value = re.sub('^https?://(dx\.)?doi.org/', '', value)
         return super().to_python(value)
 
 

--- a/proteins/forms.py
+++ b/proteins/forms.py
@@ -5,6 +5,7 @@ from django.forms.models import inlineformset_factory  # ,BaseInlineFormSet
 from django.apps import apps
 from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
+import re import sub
 from proteins.models import (Protein, State, StateTransition, Spectrum,
                              ProteinCollection, BleachMeasurement)
 from proteins.validators import validate_spectrum, validate_doi, protein_sequence_validator
@@ -55,7 +56,7 @@ class DOIField(forms.CharField):
 
     def to_python(self, value):
         if value and isinstance(value, str):
-            value = value.lstrip('https://doi.org/')
+            value = value.sub('^https?://(dx\.)?doi.org/')
         return super().to_python(value)
 
 

--- a/proteins/templates/_bleach_table.html
+++ b/proteins/templates/_bleach_table.html
@@ -35,7 +35,7 @@
 					<td class='small'>
 						{% if measurement.reference %}
 							<a href="{{measurement.reference.get_absolute_url}}">{{measurement.reference}}</a>
-							<a href="http://dx.doi.org/{{ measurement.reference.doi }}" target="_blank"><i class="fas fa-external-link-alt text-info"></i></a>
+							<a href="https://doi.org/{{ measurement.reference.doi }}" target="_blank"><i class="fas fa-external-link-alt text-info"></i></a>
 						{% endif %}
 					</td>
 				</tr>

--- a/proteins/util/_local.py
+++ b/proteins/util/_local.py
@@ -5,6 +5,7 @@ import traceback
 import pandas as pd
 from fpbase.users.models import User
 from django.utils.text import slugify
+from re import sub
 from references.models import Reference
 from .. import forms
 from ..models import (Protein, State, StateTransition, BleachMeasurement,
@@ -243,7 +244,7 @@ def importSeqs(file=None):
                     print("Non-matching sequence found for {}!".format(prot.Name))
             try:
                 if 'dx.doi' in prot.Source:
-                    doi = prot.Source.strip('https://doi.org/')
+                    doi = prot.Source.sub('^https?://(dx\.)?doi.org/', '')
                     rf += add_ref_to_prot(p, doi)
             except Exception as e:
                 # traceback.print_exc()

--- a/proteins/util/_local.py
+++ b/proteins/util/_local.py
@@ -243,7 +243,7 @@ def importSeqs(file=None):
                     print("Non-matching sequence found for {}!".format(prot.Name))
             try:
                 if 'dx.doi' in prot.Source:
-                    doi = prot.Source.strip('http://dx.doi.org/')
+                    doi = prot.Source.strip('https://doi.org/')
                     rf += add_ref_to_prot(p, doi)
             except Exception as e:
                 # traceback.print_exc()

--- a/proteins/util/_local.py
+++ b/proteins/util/_local.py
@@ -5,7 +5,7 @@ import traceback
 import pandas as pd
 from fpbase.users.models import User
 from django.utils.text import slugify
-from re import sub
+import re
 from references.models import Reference
 from .. import forms
 from ..models import (Protein, State, StateTransition, BleachMeasurement,
@@ -244,7 +244,7 @@ def importSeqs(file=None):
                     print("Non-matching sequence found for {}!".format(prot.Name))
             try:
                 if 'dx.doi' in prot.Source:
-                    doi = prot.Source.sub('^https?://(dx\.)?doi.org/', '')
+                    doi = re.sub('^https?://(dx\.)?doi.org/', '', prot.Source)
                     rf += add_ref_to_prot(p, doi)
             except Exception as e:
                 # traceback.print_exc()

--- a/references/templates/_reference.html
+++ b/references/templates/_reference.html
@@ -6,7 +6,7 @@
 		{% endfor %}
 	</p>
 	<p class='reference-details'>
-		({{ ref.year }}). <em>{{ ref.journal }}, {{ ref.volume }}</em>{% if ref.issue %}({{ ref.issue }}) {% endif %}, {{ ref.pages }}. doi: {{ ref.doi | lower }}. <a href="http://dx.doi.org/{{ ref.doi }}" target="_blank"><i class="fas fa-external-link-alt"></i> Journal</a>
+		({{ ref.year }}). <em>{{ ref.journal }}, {{ ref.volume }}</em>{% if ref.issue %}({{ ref.issue }}) {% endif %}, {{ ref.pages }}. doi: {{ ref.doi | lower }}. <a href="https://doi.org/{{ ref.doi }}" target="_blank"><i class="fas fa-external-link-alt"></i> Journal</a>
 		{% if ref.pmid %}&nbsp;&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/{{ ref.pmid }}" target="_blank"><i class="fas fa-external-link-alt"></i> Pubmed</a>{% endif %}
 	</p>
 </div>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!