### PR TITLE
Update django-autocomplete-light from 3.9.4 to 3.9.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,7 +39,7 @@ tablib==3.4.0
 scipy==1.10.1
 dnspython==2.3.0
 django-anymail==10.0  # https://github.com/anymail/django-anymail
-django-autocomplete-light==3.9.4  # https://github.com/yourlabs/django-autocomplete-light
+django-autocomplete-light==3.9.7  # https://github.com/yourlabs/django-autocomplete-light
 django-avatar==7.1.1
 
 numpy==1.24.3


### PR DESCRIPTION
copilot:summary