### PR TITLE
add dyes to the graphql api

### DIFF
--- a/backend/fpbase/forms.py
+++ b/backend/fpbase/forms.py
@@ -37,5 +37,7 @@ class ContactForm(forms.Form):
 
 
 class CustomSignupForm(SignupForm):
-    captcha = ReCaptchaField(label="", widget=ReCaptchaV3(attrs={"required_score": 0.85}))
+    # only if not in debug mode
+    if not settings.DEBUG:
+        captcha = ReCaptchaField(label="", widget=ReCaptchaV3(attrs={"required_score": 0.85}))
     field_order = ["username", "email", "password1", "password2", "captcha"]

--- a/backend/proteins/models/spectrum.py
+++ b/backend/proteins/models/spectrum.py
@@ -89,7 +89,7 @@ class SpectrumManager(models.Manager):
             self.get_queryset().filter(category=self.DYE).values_list("owner_dye__slug", "owner_dye__name").distinct()
         )
 
-    def sluglist(self):
+    def sluglist(self, filters: dict | None = None):
         """probably using this one going forward for spectra page"""
 
         owners = ["state", "dye", "filter", "light", "camera"]
@@ -107,7 +107,10 @@ class SpectrumManager(models.Manager):
         for suffix in ["slug", "id", "name"]:
             for owner in owners:
                 vals.append(f"owner_{owner}__{suffix}")
-        Q = self.get_queryset().values(*vals)
+        Q = self.get_queryset()
+        if filters:
+            Q = Q.filter(**filters)
+        Q = Q.values(*vals)
 
         out = []
         for v in Q:


### PR DESCRIPTION
This allows new graphql queries:

dyes list
```graphql
{
dyes {
    name
    id
  }
}
```

dyes detail using name or id
```graphql
{
dye(name:"Alexa Fluor 488") {
    name
    id
    spectra {
      id
      data
    }
  }
}
```

and filtering spectra based on category or subtype

```graphql
{
spectra(category:"P" subtype:"EX"){
    id
    subtype
    category
  }
}
```

cc @ec363