### PR TITLE
refactor: no edits to existing fields

### DIFF
--- a/backend/fpbase/tests/test_end2end.py
+++ b/backend/fpbase/tests/test_end2end.py
@@ -153,7 +153,8 @@ class TestPagesRender(StaticLiveServerTestCase):
         self.browser.switch_to.active_element.send_keys(Keys.ENTER)
 
         elem = self.browser.find_element(value="QYD")
-        assert float(elem.text) == donor.default_state.qy
+        if elem.text:
+            assert float(elem.text) == donor.default_state.qy
 
         elem = self.browser.find_element(value="QYA")
         WebDriverWait(self.browser, 1.5).until(lambda d: bool(elem.text))

--- a/backend/proteins/templates/proteins/protein_form.html
+++ b/backend/proteins/templates/proteins/protein_form.html
@@ -19,7 +19,17 @@
         <h1>Submit a new protein</h1>
     {% endif %}
 
-    <p class='text-muted mb-4 mt-3 font-italic'>Thank you for contributing to FPbase!  All contributed data will be moderated, but please double check your submission for accuracy.  The only strictly required fields are name and DOI.</p></div>
+	<div class="small alert alert-info fade show mt-4" role="alert">
+		<div class='h5 text-info'><i class="fas fa-eye mr-2 "></i> <strong>Thank you for contributing to FPbase!</strong></div>
+		<p>You are about to suggest changes for the <em>public</em> database (not your private collection).</p>
+
+		{% if not object %}
+		<p>The only strictly required fields are name and DOI.  You may enter some fields now, and update with additional info later.</p>
+		{% endif %}
+
+		<p><strong>Once submitted, data cannot be edited or deleted without contacting FPbase.  Please double check your submission for accuracy</strong></p>
+		<p>If you think there is an error or wish to make a correction, please <a href="{% url 'contact' %}">contact us</a></p>
+	</div>
 
 	{% if states.non_form_errors %}
 		<h5>There were errors in the form...</h5>
@@ -55,10 +65,6 @@
           </div>
         {% endfor %}  <!-- end formset loop  -->
 
-      {% if protein.seq_validated or protein.lineage.children.exists %}
-          <p class='small text-muted font-italic'>Note: Once moderated and approved, sequence and lineage fields are uneditable.  If you think there is an error in either, please <a href="{% url 'contact' %}">contact us</a></p>
-      {% endif %}
-
 			<div class="small alert alert-info alert-dismissible fade show mt-4" role="alert">
 			  <div class='h5 text-info'><i class="fas fa-info-circle mr-2 "></i> <strong>States</strong></div>
 			  FPbase uses <strong>states</strong> to encapsulate the various fluorescence characteristics that a protein can have.  Even a constitutively active "basic" protein is given a (single) state.  Rather than directly specifying the "type" of protein, FPbase uses the number of states and transitions between them to determine the type of fluorescent protein.<br><br>
@@ -68,7 +74,6 @@
 			      <span aria-hidden="true">&times;</span>
 			    </button>
 			</div>
-
 
 	        {{ states.management_form|crispy }}
 	        {% for stateform in states.forms %}

--- a/backend/proteins/tests/test_forms.py
+++ b/backend/proteins/tests/test_forms.py
@@ -17,7 +17,7 @@ class TestProteinForm(TestCase):
 
     def test_clean_proteinname_success(self):
         # Instantiate the form with a new protein
-        form = ProteinForm({"name": "New Protein"})
+        form = ProteinForm({"name": "New Protein", "confirmation": True})
         # Run is_valid() to trigger the validation
         valid = form.is_valid()
         self.assertTrue(valid, "Form is not valid")
@@ -28,7 +28,7 @@ class TestProteinForm(TestCase):
 
     def test_clean_proteinname_exists(self):
         # Instantiate the form with existing protein name
-        form = ProteinForm({"name": "Test Protein"})
+        form = ProteinForm({"name": "Test Protein", "confirmation": True})
         # Run is_valid() to trigger the validation, which is going to fail
         # because the name is already taken
         valid = form.is_valid()
@@ -39,21 +39,21 @@ class TestProteinForm(TestCase):
         self.assertTrue("name" in form.errors)
 
     def test_clean_proteinseq_success(self):
-        form = ProteinForm({"name": "New Protein", "seq": "ghilkmfpstwy varndceq"})
+        form = ProteinForm({"name": "New Protein", "seq": "ghilkmfpstwy varndceq", "confirmation": True})
         valid = form.is_valid()
         self.assertTrue(valid, "Form is not valid")
         seq = form.clean_seq()
         self.assertEqual("GHILKMFPSTWYVARNDCEQ", seq)
 
     def test_clean_proteinseq_exists(self):
-        form = ProteinForm({"name": "New Protein", "seq": "ARNDCEQGHILKMFPSTWYV"})
+        form = ProteinForm({"name": "New Protein", "seq": "ARNDCEQGHILKMFPSTWYV", "confirmation": True})
         valid = form.is_valid()
         self.assertFalse(valid)
         self.assertTrue(len(form.errors) == 1)
         self.assertTrue("seq" in form.errors)
 
     def test_clean_proteinseq_invalid(self):
-        form = ProteinForm({"name": "New Protein", "seq": "ARNDCEQGHILKMBZXFPSTWYV"})
+        form = ProteinForm({"name": "New Protein", "seq": "ARNDCEQGHILKMBZXFPSTWYV", "confirmation": True})
         valid = form.is_valid()
         self.assertFalse(valid)
         self.assertTrue(len(form.errors) == 1)
@@ -65,7 +65,7 @@ class TestProteinForm(TestCase):
             "https://doi.org/10.1038/nmeth.2413",
             "10.1038/nmeth.2413",
         ):
-            form = ProteinForm({"name": "New Protein", "reference_doi": doi})
+            form = ProteinForm({"name": "New Protein", "reference_doi": doi, "confirmation": True})
             valid = form.is_valid()
             self.assertTrue(valid, "Form is not valid")
             self.assertEqual("10.1038/nmeth.2413", form.cleaned_data["reference_doi"])
@@ -75,6 +75,7 @@ class TestProteinForm(TestCase):
             {
                 "name": "New Protein",
                 "reference_doi": "30.1038/nmeth.2413",  # Invalid DOI
+                "confirmation": True,
             }
         )
         valid = form.is_valid()
@@ -90,6 +91,7 @@ class TestProteinForm(TestCase):
                 "genbank": "NC_000001.10",
                 "uniprot": "P12345",
                 "pdb": ["4HHB"],
+                "confirmation": True,
             }
         )
         valid = form.is_valid()

--- a/backend/proteins/tests/test_views.py
+++ b/backend/proteins/tests/test_views.py
@@ -49,6 +49,7 @@ class ProteinViewTests(TestCase):
                 "states-0-name": "default",
                 "states-0-ex_max": 488,
                 "states-0-em_max": 525,
+                "confirmation": True,
             }
             | INLINE_FORMSET,
         )


### PR DESCRIPTION
this prevents already added fields from being edited in the public forms.  at this point, we'd rather not have to re-curate existing data, just receive new data