### PR TITLE
Add structlog-sentry dependency and configure SentryProcessor 

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -8,10 +8,12 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
+import logging
 from pathlib import Path
 
 import environ
 import structlog
+from structlog_sentry import SentryProcessor
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 APPS_DIR = ROOT_DIR / "fpbase"
@@ -469,6 +471,10 @@ STRUCTLOG_SHARED_PROCESSORS = [
     structlog.stdlib.add_logger_name,
     structlog.processors.TimeStamper(fmt="iso"),
     add_sentry_context,  # Add Sentry event ID for exception correlation
+    # SentryProcessor sends ERROR+ events to Sentry BEFORE JSON formatting
+    # This ensures Sentry gets clean, structured data instead of JSON strings
+    # level=INFO -> sends INFO+ as breadcrumbs, event_level=ERROR -> sends ERROR+ as events
+    SentryProcessor(level=logging.INFO, event_level=logging.ERROR),
 ]
 
 # Default structlog configuration (production-safe)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "scout-apm>=3.4.0",
     "structlog>=24.1.0",
     "django-structlog>=8.1.0",
+    "structlog-sentry>=2.1.0",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1158,6 +1158,7 @@ dependencies = [
     { name = "scout-apm" },
     { name = "sentry-sdk" },
     { name = "structlog" },
+    { name = "structlog-sentry" },
     { name = "tablib" },
     { name = "whitenoise", extra = ["brotli"] },
 ]
@@ -1235,6 +1236,7 @@ requires-dist = [
     { name = "scout-apm", specifier = ">=3.4.0" },
     { name = "sentry-sdk", specifier = ">=2.8" },
     { name = "structlog", specifier = ">=24.1.0" },
+    { name = "structlog-sentry", specifier = ">=2.1.0" },
     { name = "tablib", specifier = ">=3.4.0" },
     { name = "whitenoise", extras = ["brotli"], specifier = ">=6.11.0" },
 ]
@@ -2884,6 +2886,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/b9/6e672db4fec07349e7a8a8172c1a6ae235c58679ca29c3f86a61b5e59ff3/structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4", size = 1369138, upload-time = "2025-06-02T08:21:12.971Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4a/97ee6973e3a73c74c8120d59829c3861ea52210667ec3e7a16045c62b64d/structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c", size = 68720, upload-time = "2025-06-02T08:21:11.43Z" },
+]
+
+[[package]]
+name = "structlog-sentry"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sentry-sdk" },
+    { name = "structlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/c8/a6d66c4a691a47c9c572ab84640012bb70c8c4f710763bd544236d98f278/structlog_sentry-2.2.1.tar.gz", hash = "sha256:78cf8751c7712e361d9d5e82fcde6c3f692a67e3e67068ccdd46448014636138", size = 6855, upload-time = "2024-11-12T14:31:51.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/ba/1b1226db704c16426d59e1fcbeaf5138dbc5a50d424aab92b453d33add47/structlog_sentry-2.2.1-py3-none-any.whl", hash = "sha256:868c82348bc18b7d51ef8f878c57e82835c1758dba38f7589fa02a267096a95d", size = 11218, upload-time = "2024-11-12T14:31:50.594Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
fixes the ugly sentry reports we've been getting after #287 