### PR TITLE
fix: remove runtimeChunk single, fix all the bugs

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -171,9 +171,6 @@ module.exports = {
   },
   plugins,
   optimization: {
-    // Share webpack runtime across all bundles
-    runtimeChunk: "single",
-
     minimizer: [
       new TerserJSPlugin(),
       new CssMinimizerPlugin({


### PR DESCRIPTION
this PR fixes all kinds of stupid bugs that were introduced by the move to `runtimeChunk: single` in #303 

https://webpack.js.org/configuration/optimization/#optimizationruntimechunk

specifically:

- navigation dropdowns broken on all pages that load react apps
- using the spacebar to bring up the quick-entry modal  in the spectra viewer wouldn't actually update the chart
- probably other dumb things I hadn't noticed