### PR TITLE
Fix PDB structure viewer crash - Fixes FPBASE-5NH

### DIFF
--- a/frontend/src/my-litemol.js
+++ b/frontend/src/my-litemol.js
@@ -394,12 +394,30 @@ async function getPDBinfo(pdbIds) {
 
     const select = $("#pdb_select")
 
-    // Sort by resolution (best first)
-    pdbIds.sort((a, b) => (pdbInfo[a].resolution > pdbInfo[b].resolution ? 1 : -1))
+    // Sort by resolution (best first), handling missing resolution data
+    // Entries without resolution (e.g., NMR structures) are sorted to the end
+    pdbIds.sort((a, b) => {
+      const resA = pdbInfo[a]?.resolution
+      const resB = pdbInfo[b]?.resolution
+
+      // If both have resolution, sort by value (lower is better)
+      if (resA !== undefined && resB !== undefined) {
+        return resA - resB
+      }
+      // If only A has resolution, it comes first
+      if (resA !== undefined) return -1
+      // If only B has resolution, it comes first
+      if (resB !== undefined) return 1
+      // If neither has resolution, maintain original order
+      return 0
+    })
 
     // Populate dropdown
     pdbIds.forEach((id) => {
-      select.append($("<option>", { value: id }).html(`${id} (${pdbInfo[id].resolution} Å)`))
+      const resolution = pdbInfo[id]?.resolution
+      const displayText =
+        resolution !== undefined ? `${id} (${resolution.toFixed(2)} Å)` : `${id} (resolution N/A)`
+      select.append($("<option>", { value: id }).html(displayText))
     })
 
     initLiteMol("#litemol-viewer", select)


### PR DESCRIPTION
## Summary
- Fixes crash in 3D protein structure viewer when PDB entries lack resolution data
- Resolves Sentry issue FPBASE-5NH (28 occurrences affecting 2 users)

## Changes
- Added safe resolution access using optional chaining (`?.`)
- Rewrote sort function to gracefully handle missing resolution metadata
- Entries with resolution data are sorted first (by ascending value)
- Entries without resolution display "N/A" instead of crashing
- Fixed bug: now using proper numeric comparison instead of string comparison

## Problem
The PDB viewer was throwing `TypeError: Cannot read properties of undefined (reading 'resolution')` when trying to sort structures. This occurred because some PDB entries (particularly NMR structures) don't include resolution data in their GraphQL response from RCSB.
