### PR TITLE
fix: restrict Algolia public search key and debounce autocomplete

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -380,7 +380,7 @@ GOOGLE_API_PRIVATE_KEY_ID = env("GOOGLE_API_PRIVATE_KEY_ID", default="")
 MAXMIND_API_KEY = env("MAXMIND_API_KEY", default="")
 
 ALGOLIA_SUFFIX = "dev" if (DEBUG or ("staging" in env("SENTRY_PROJECT", default=""))) else "prod"
-ALGOLIA_PUBLIC_KEY = "421b453d4f93e332ebd0c7f3ace29476"
+ALGOLIA_PUBLIC_KEY = env("ALGOLIA_PUBLIC_KEY", default="4c8b117e4653fe576f51829e74030238")
 ALGOLIA = {
     "APPLICATION_ID": "9WAWQMVNTB",
     "API_KEY": env("ALGOLIA_API_KEY", default=""),

--- a/frontend/src/js/algolia.js
+++ b/frontend/src/js/algolia.js
@@ -4,6 +4,10 @@ const $ = window.jQuery // jQuery loaded from CDN
 // Use 500 to be safe (accounting for multi-byte characters)
 const MAX_QUERY_LENGTH = 500
 
+// Debounce keystrokes: each dataset issues its own Algolia query, so an
+// undebounced 8-character search costs ~18 search requests instead of 3.
+const SEARCH_DEBOUNCE_MS = 250
+
 function checkObject(val, prop, str) {
   var propDict = {
     genbank: "GenBank",
@@ -242,6 +246,7 @@ export default async function initAutocomplete() {
           source: createLimitedSource(proteinIndex, {
             hitsPerPage: 5,
           }),
+          debounce: SEARCH_DEBOUNCE_MS,
           displayKey: "name",
           templates: {
             suggestion: (suggestion) => {
@@ -290,6 +295,7 @@ export default async function initAutocomplete() {
           source: createLimitedSource(referenceIndex, {
             hitsPerPage: 3,
           }),
+          debounce: SEARCH_DEBOUNCE_MS,
           displayKey: "citation",
           templates: {
             suggestion: (suggestion) => {
@@ -304,6 +310,7 @@ export default async function initAutocomplete() {
           source: createLimitedSource(organismIndex, {
             hitsPerPage: 2,
           }),
+          debounce: SEARCH_DEBOUNCE_MS,
           displayKey: "scientific_name",
           templates: {
             suggestion: (suggestion) => {


### PR DESCRIPTION
The public search key served on every page had no restrictions: no rate limit, no hit cap, and no index scoping. Request logs show ~46% of search traffic is scripted (python-requests, Python-urllib, node, spoofed UAs), 73% of it empty or `*` queries at hitsPerPage=1000 — bulk index extraction. Usage stepped from ~3.2K/day (Dec-Mar) to ~13K/day, and stupid people with their agents broke search for everyone :(

- Serve a restricted key instead: more minimally scoped with rate limits. Read from the environment so future rotations don't need a deploy.
- Debounce the three autocomplete datasets.