### PR TITLE
fix: 500 on comparison page for proteins with non-ASCII names

### DIFF
--- a/backend/proteins/models/protein.py
+++ b/backend/proteins/models/protein.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import sys
+import unicodedata
 from collections import Counter
 from random import choices
 from subprocess import PIPE, run
@@ -69,11 +70,25 @@ def prot_uuid(k: int = 5, opts: Sequence[str] = "ABCDEFGHJKLMNOPQRSTUVWXYZ123456
         return prot_uuid(k, opts)
 
 
+def ascii_name(name: str) -> str:
+    """Best-effort ASCII rendering of `name`, for FASTA headers fed to muscle/blast."""
+    out = []
+    for char in unicodedata.normalize("NFKD", name):
+        if char.isascii():
+            out.append(char)
+        elif unicodedata.category(char).startswith(("P", "Z")):
+            out.append("-")
+        # last word of e.g. "GREEK SMALL LETTER KAPPA" is a decent stand-in
+        elif not unicodedata.combining(char) and (words := unicodedata.name(char, "").split()):
+            out.append(words[-1].lower())
+    return "".join(out)
+
+
 class _ProteinQuerySet(models.QuerySet):
     def fasta(self):
         seqs = list(self.exclude(seq__isnull=True).values("uuid", "name", "seq"))
         for s in seqs:
-            s["name"] = s["name"].replace("\u03b1", "-alpha").replace("β", "-beta")
+            s["name"] = ascii_name(s["name"])
         return io.StringIO("\n".join([">{uuid} {name}\n{seq}".format(**s) for s in seqs]))
 
     def to_tree(self, output="clw"):
@@ -84,7 +99,7 @@ class _ProteinQuerySet(models.QuerySet):
         cmd += ["-maxiters", "2", "-diags", "-quiet", f"-{output}"]
         # make tree
         cmd += ["-cluster", "neighborjoining", "-tree2", "tree.phy"]
-        result = run(cmd, input=fasta.read(), stdout=PIPE, encoding="ascii")
+        result = run(cmd, input=fasta.read(), stdout=PIPE, encoding="utf-8")
         with open("tree.phy") as handle:
             newick = handle.read().replace("\n", "")
         os.remove("tree.phy")

--- a/backend/tests/test_proteins/test_models.py
+++ b/backend/tests/test_proteins/test_models.py
@@ -1,6 +1,10 @@
+import pytest
 from django.test import TestCase
 
 from proteins.models import Protein, Spectrum, State
+from proteins.models.protein import ascii_name
+
+SEQ = "MVSKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTLTYGVQCFS"
 
 
 class TestProteinModel(TestCase):
@@ -62,3 +66,35 @@ class TestProteinModel(TestCase):
         # The cached property should be invalidated and return the new values
         assert spectrum.y == new_y, f"Expected {new_y}, got {spectrum.y}"
         assert spectrum.y != original_y
+
+
+@pytest.mark.parametrize(
+    ("name", "expect"),
+    [
+        ("mKOκ", "mKOkappa"),
+        ("Nữ", "Nu"),
+        ("lanRFP-ΔS83l", "lanRFP-deltaS83l"),
+        ("TeAPCα", "TeAPCalpha"),  # noqa: RUF001
+        ("αGFP", "alphaGFP"),  # noqa: RUF001
+        ("β-lactamase", "beta-lactamase"),
+        ("mCherry–2", "mCherry-2"),  # noqa: RUF001  # en dash
+        ("mCherry", "mCherry"),
+    ],
+)
+def test_ascii_name(name: str, expect: str) -> None:
+    assert ascii_name(name) == expect
+
+
+@pytest.mark.django_db
+def test_fasta_is_ascii_for_unicode_names() -> None:
+    """FASTA headers must be ASCII: muscle/blast choke on non-ascii input."""
+    names = ["mKOκ", "Nữ", "lanRFP-ΔS83l"]
+    for i, name in enumerate(names):
+        # seq is unique across proteins
+        Protein.objects.create(name=name, seq=SEQ + "A" * i)
+
+    fasta = Protein.objects.filter(name__in=names).fasta().read()
+
+    fasta.encode("ascii")  # raises UnicodeEncodeError on regression
+    for name in names:
+        assert ascii_name(name) in fasta


### PR DESCRIPTION
Comparing 3+ proteins that have sequences raised UnicodeEncodeError when any of their names contained a non-ASCII character, e.g.

  /compare/mkokappa,venus,mtagbfp,dsred2/
  UnicodeEncodeError: 'ascii' codec can't encode character 'κ'

The >2-sequence branch of ComparisonView shells out to muscle via _ProteinQuerySet.to_tree(), which pipes a FASTA built by fasta(). That FASTA sanitized exactly two characters (α and β) before being written to the subprocess with encoding="ascii", so any other non-ASCII character in a protein name crashed the write. Two proteins take a different, pure Python path, which is why smaller comparisons worked.

Replace the two-character denylist with a general ascii_name() helper built on unicodedata: NFKD-decompose, keep ASCII, map Unicode punctuation and spaces to "-", drop combining marks, and fall back to the last word of a character's Unicode name. This generalizes the previous behavior rather than changing it (α still renders as "alpha"), and mKOκ becomes "mKOkappa", matching the slug already in use. The name is user-visible as the hit title in blast results, so transliterating beats dropping the character, which would collapse mKOκ onto the distinct protein mKO.

Also switch the muscle subprocess to encoding="utf-8" so the crash site cannot raise even if a name slips through.

Affects mKOκ, Nữ and lanRFP-ΔS83l on production.